### PR TITLE
Update to actionlint 1.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sosukesuzuki/node-actionlint
 
 go 1.16
 
-require github.com/rhysd/actionlint v1.4.3
+require github.com/rhysd/actionlint v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/rhysd/actionlint v1.4.3 h1:pDsAVKikdeE2E1YPwrcjL56C9eci6RjlsAIr+OFW9RA=
-github.com/rhysd/actionlint v1.4.3/go.mod h1:if6NbiMd3/IXKr1JzxWGLPCtnNjOhTJu93CpNjp0Oj8=
+github.com/rhysd/actionlint v1.5.0 h1:FHkB53VNluzvE3yuK5qwqxO8m/zRFAYsvWCi7k9U8W0=
+github.com/rhysd/actionlint v1.5.0/go.mod h1:if6NbiMd3/IXKr1JzxWGLPCtnNjOhTJu93CpNjp0Oj8=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=


### PR DESCRIPTION
Update to [actionlint 1.5.0](https://github.com/rhysd/actionlint/releases/tag/v1.5.0).