### PR TITLE
Update actionlint to 1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sosukesuzuki/node-actionlint
 
 go 1.16
 
-require github.com/rhysd/actionlint v1.5.0
+require github.com/rhysd/actionlint v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,13 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/rhysd/actionlint v1.5.0 h1:FHkB53VNluzvE3yuK5qwqxO8m/zRFAYsvWCi7k9U8W0=
-github.com/rhysd/actionlint v1.5.0/go.mod h1:if6NbiMd3/IXKr1JzxWGLPCtnNjOhTJu93CpNjp0Oj8=
+github.com/rhysd/actionlint v1.6.0 h1:ejw2xwqp77Xu9OEgQtx5bjTwv/Szmng1S9Mp9Lbhgro=
+github.com/rhysd/actionlint v1.6.0/go.mod h1:E5RIDcgBIAEXhknfons++siy4CcuByd1qObNU/X+lYI=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Update to https://github.com/rhysd/actionlint/releases/tag/v1.6.0